### PR TITLE
Update permissions to create mvn dependency graph

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -9,7 +9,7 @@
 name: Build Backend
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 on:


### PR DESCRIPTION
Set contents permission to `write`

https://github.com/advanced-security/maven-dependency-submission-action

> This action writes informations in the repository dependency graph, so if you are using the default token, you need to set the contents: write permission to the workflow or job. If you are using a personal access token, this token must have the repo scope. ([API used by this action](https://docs.github.com/en/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository))