### PR TITLE
Replace IBM with PQCA in license header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
             <licenseHeader> <!-- specify either content or file, but not both -->
               <content>/*
  * CBOMkit
- * Copyright (C) $YEAR IBM
+ * Copyright (C) $YEAR PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/compliance/CryptographicAsset.java
+++ b/src/main/java/com/ibm/domain/compliance/CryptographicAsset.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/compliance/PolicyIdentifier.java
+++ b/src/main/java/com/ibm/domain/compliance/PolicyIdentifier.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/CBOM.java
+++ b/src/main/java/com/ibm/domain/scanning/CBOM.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/Commit.java
+++ b/src/main/java/com/ibm/domain/scanning/Commit.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/GitUrl.java
+++ b/src/main/java/com/ibm/domain/scanning/GitUrl.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/Language.java
+++ b/src/main/java/com/ibm/domain/scanning/Language.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/LanguageScan.java
+++ b/src/main/java/com/ibm/domain/scanning/LanguageScan.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/Revision.java
+++ b/src/main/java/com/ibm/domain/scanning/Revision.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/ScanAggregate.java
+++ b/src/main/java/com/ibm/domain/scanning/ScanAggregate.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/ScanId.java
+++ b/src/main/java/com/ibm/domain/scanning/ScanId.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/ScanMetadata.java
+++ b/src/main/java/com/ibm/domain/scanning/ScanMetadata.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/ScanRequest.java
+++ b/src/main/java/com/ibm/domain/scanning/ScanRequest.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/ScanUrl.java
+++ b/src/main/java/com/ibm/domain/scanning/ScanUrl.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/authentication/ICredentials.java
+++ b/src/main/java/com/ibm/domain/scanning/authentication/ICredentials.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/authentication/PersonalAccessToken.java
+++ b/src/main/java/com/ibm/domain/scanning/authentication/PersonalAccessToken.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/authentication/UsernameAndPasswordCredentials.java
+++ b/src/main/java/com/ibm/domain/scanning/authentication/UsernameAndPasswordCredentials.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/errors/CBOMSerializationFailed.java
+++ b/src/main/java/com/ibm/domain/scanning/errors/CBOMSerializationFailed.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/errors/CommitHashAlreadyExists.java
+++ b/src/main/java/com/ibm/domain/scanning/errors/CommitHashAlreadyExists.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/errors/GitUrlAlreadyResolved.java
+++ b/src/main/java/com/ibm/domain/scanning/errors/GitUrlAlreadyResolved.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/errors/InvalidScanUrl.java
+++ b/src/main/java/com/ibm/domain/scanning/errors/InvalidScanUrl.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/errors/NoValidProjectIdentifierForScan.java
+++ b/src/main/java/com/ibm/domain/scanning/errors/NoValidProjectIdentifierForScan.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2025 IBM
+ * Copyright (C) 2025 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/errors/PackageFolderAlreadyExists.java
+++ b/src/main/java/com/ibm/domain/scanning/errors/PackageFolderAlreadyExists.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/errors/RevisionAlreadyExists.java
+++ b/src/main/java/com/ibm/domain/scanning/errors/RevisionAlreadyExists.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/errors/ScanResultForLanguageAlreadyExists.java
+++ b/src/main/java/com/ibm/domain/scanning/errors/ScanResultForLanguageAlreadyExists.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/errors/UnexpectedMetadata.java
+++ b/src/main/java/com/ibm/domain/scanning/errors/UnexpectedMetadata.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/events/CommitHashIdentifiedEvent.java
+++ b/src/main/java/com/ibm/domain/scanning/events/CommitHashIdentifiedEvent.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/events/GitUrlResolvedEvent.java
+++ b/src/main/java/com/ibm/domain/scanning/events/GitUrlResolvedEvent.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/events/LanguageScanDoneEvent.java
+++ b/src/main/java/com/ibm/domain/scanning/events/LanguageScanDoneEvent.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/events/PackageFolderResolvedEvent.java
+++ b/src/main/java/com/ibm/domain/scanning/events/PackageFolderResolvedEvent.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/events/PurlScanRequestedEvent.java
+++ b/src/main/java/com/ibm/domain/scanning/events/PurlScanRequestedEvent.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/events/RevisionIdentifiedEvent.java
+++ b/src/main/java/com/ibm/domain/scanning/events/RevisionIdentifiedEvent.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/events/ScanFinishedEvent.java
+++ b/src/main/java/com/ibm/domain/scanning/events/ScanFinishedEvent.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/domain/scanning/events/ScanRequestedEvent.java
+++ b/src/main/java/com/ibm/domain/scanning/events/ScanRequestedEvent.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/CommandBus.java
+++ b/src/main/java/com/ibm/infrastructure/CommandBus.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/Configuration.java
+++ b/src/main/java/com/ibm/infrastructure/Configuration.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/DomainEventBus.java
+++ b/src/main/java/com/ibm/infrastructure/DomainEventBus.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/QueryBus.java
+++ b/src/main/java/com/ibm/infrastructure/QueryBus.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/compliance/ComplianceFinding.java
+++ b/src/main/java/com/ibm/infrastructure/compliance/ComplianceFinding.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/compliance/ComplianceLevel.java
+++ b/src/main/java/com/ibm/infrastructure/compliance/ComplianceLevel.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/compliance/ComplianceResult.java
+++ b/src/main/java/com/ibm/infrastructure/compliance/ComplianceResult.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/compliance/IComplianceConfiguration.java
+++ b/src/main/java/com/ibm/infrastructure/compliance/IComplianceConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/compliance/service/BasicCryptographicAssetPolicyResult.java
+++ b/src/main/java/com/ibm/infrastructure/compliance/service/BasicCryptographicAssetPolicyResult.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/compliance/service/BasicQuantumSafeComplianceService.java
+++ b/src/main/java/com/ibm/infrastructure/compliance/service/BasicQuantumSafeComplianceService.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/compliance/service/ComplianceCheckResultDTO.java
+++ b/src/main/java/com/ibm/infrastructure/compliance/service/ComplianceCheckResultDTO.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/compliance/service/IComplianceService.java
+++ b/src/main/java/com/ibm/infrastructure/compliance/service/IComplianceService.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/compliance/service/ICryptographicAssetPolicyResult.java
+++ b/src/main/java/com/ibm/infrastructure/compliance/service/ICryptographicAssetPolicyResult.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/database/readmodels/CBOMReadModel.java
+++ b/src/main/java/com/ibm/infrastructure/database/readmodels/CBOMReadModel.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/database/readmodels/CBOMReadRepository.java
+++ b/src/main/java/com/ibm/infrastructure/database/readmodels/CBOMReadRepository.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/database/readmodels/ICBOMReadRepository.java
+++ b/src/main/java/com/ibm/infrastructure/database/readmodels/ICBOMReadRepository.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/errors/AggregateReconstructionFailed.java
+++ b/src/main/java/com/ibm/infrastructure/errors/AggregateReconstructionFailed.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2025 IBM
+ * Copyright (C) 2025 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/errors/ClientDisconnected.java
+++ b/src/main/java/com/ibm/infrastructure/errors/ClientDisconnected.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/errors/EntityNotFoundById.java
+++ b/src/main/java/com/ibm/infrastructure/errors/EntityNotFoundById.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/progress/IProgressDispatcher.java
+++ b/src/main/java/com/ibm/infrastructure/progress/IProgressDispatcher.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/progress/ProgressMessage.java
+++ b/src/main/java/com/ibm/infrastructure/progress/ProgressMessage.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/progress/ProgressMessageType.java
+++ b/src/main/java/com/ibm/infrastructure/progress/ProgressMessageType.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/progress/WebSocketProgressDispatcher.java
+++ b/src/main/java/com/ibm/infrastructure/progress/WebSocketProgressDispatcher.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/scanning/IScanConfiguration.java
+++ b/src/main/java/com/ibm/infrastructure/scanning/IScanConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/scanning/repositories/Scan.java
+++ b/src/main/java/com/ibm/infrastructure/scanning/repositories/Scan.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/scanning/repositories/ScanRepository.java
+++ b/src/main/java/com/ibm/infrastructure/scanning/repositories/ScanRepository.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/infrastructure/scanning/repositories/ScanResult.java
+++ b/src/main/java/com/ibm/infrastructure/scanning/repositories/ScanResult.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/presentation/api/v1/Status.java
+++ b/src/main/java/com/ibm/presentation/api/v1/Status.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/presentation/api/v1/compliance/ComplianceResource.java
+++ b/src/main/java/com/ibm/presentation/api/v1/compliance/ComplianceResource.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/presentation/api/v1/database/CBOMResource.java
+++ b/src/main/java/com/ibm/presentation/api/v1/database/CBOMResource.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/presentation/api/v1/scanning/Credentials.java
+++ b/src/main/java/com/ibm/presentation/api/v1/scanning/Credentials.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/presentation/api/v1/scanning/ScanRequest.java
+++ b/src/main/java/com/ibm/presentation/api/v1/scanning/ScanRequest.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/presentation/api/v1/scanning/ScanningResource.java
+++ b/src/main/java/com/ibm/presentation/api/v1/scanning/ScanningResource.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/compliance/errors/CouldNotFindCBOMForGitRepository.java
+++ b/src/main/java/com/ibm/usecases/compliance/errors/CouldNotFindCBOMForGitRepository.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/compliance/errors/ErrorWhileParsingStringToCBOM.java
+++ b/src/main/java/com/ibm/usecases/compliance/errors/ErrorWhileParsingStringToCBOM.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/compliance/queries/RequestComplianceCheckForCBOMQuery.java
+++ b/src/main/java/com/ibm/usecases/compliance/queries/RequestComplianceCheckForCBOMQuery.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/compliance/queries/RequestComplianceCheckForCBOMQueryHandler.java
+++ b/src/main/java/com/ibm/usecases/compliance/queries/RequestComplianceCheckForCBOMQueryHandler.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/compliance/queries/RequestComplianceCheckForScannedGitRepositoryQuery.java
+++ b/src/main/java/com/ibm/usecases/compliance/queries/RequestComplianceCheckForScannedGitRepositoryQuery.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/compliance/queries/RequestComplianceCheckForScannedGitRepositoryQueryHandler.java
+++ b/src/main/java/com/ibm/usecases/compliance/queries/RequestComplianceCheckForScannedGitRepositoryQueryHandler.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/compliance/service/CompliancePreparationService.java
+++ b/src/main/java/com/ibm/usecases/compliance/service/CompliancePreparationService.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/database/errors/NoCBOMForProjectIdentifierFound.java
+++ b/src/main/java/com/ibm/usecases/database/errors/NoCBOMForProjectIdentifierFound.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/database/queries/GetCBOMByProjectIdentifierQuery.java
+++ b/src/main/java/com/ibm/usecases/database/queries/GetCBOMByProjectIdentifierQuery.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/database/queries/GetCBOMByProjectIdentifierQueryHandler.java
+++ b/src/main/java/com/ibm/usecases/database/queries/GetCBOMByProjectIdentifierQueryHandler.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/database/queries/ListStoredCBOMsQuery.java
+++ b/src/main/java/com/ibm/usecases/database/queries/ListStoredCBOMsQuery.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/database/queries/ListStoredCBOMsQueryHandler.java
+++ b/src/main/java/com/ibm/usecases/database/queries/ListStoredCBOMsQueryHandler.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/commands/CloneGitRepositoryCommand.java
+++ b/src/main/java/com/ibm/usecases/scanning/commands/CloneGitRepositoryCommand.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/commands/FetchDataFromDepsDevCommand.java
+++ b/src/main/java/com/ibm/usecases/scanning/commands/FetchDataFromDepsDevCommand.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/commands/IdentifyPackageFolderCommand.java
+++ b/src/main/java/com/ibm/usecases/scanning/commands/IdentifyPackageFolderCommand.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/commands/IndexModulesCommand.java
+++ b/src/main/java/com/ibm/usecases/scanning/commands/IndexModulesCommand.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/commands/RequestScanCommand.java
+++ b/src/main/java/com/ibm/usecases/scanning/commands/RequestScanCommand.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/commands/RequestScanCommandHandler.java
+++ b/src/main/java/com/ibm/usecases/scanning/commands/RequestScanCommandHandler.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/commands/ResolvePurlCommand.java
+++ b/src/main/java/com/ibm/usecases/scanning/commands/ResolvePurlCommand.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/commands/ScanCommand.java
+++ b/src/main/java/com/ibm/usecases/scanning/commands/ScanCommand.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/errors/GitCloneFailed.java
+++ b/src/main/java/com/ibm/usecases/scanning/errors/GitCloneFailed.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/errors/GitCloneResultNotAvailable.java
+++ b/src/main/java/com/ibm/usecases/scanning/errors/GitCloneResultNotAvailable.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/errors/NoCBOMForScan.java
+++ b/src/main/java/com/ibm/usecases/scanning/errors/NoCBOMForScan.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/errors/NoCommitProvided.java
+++ b/src/main/java/com/ibm/usecases/scanning/errors/NoCommitProvided.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/errors/NoDataAvailableInDepsDevForPurl.java
+++ b/src/main/java/com/ibm/usecases/scanning/errors/NoDataAvailableInDepsDevForPurl.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/errors/NoGitUrlSpecifiedForScan.java
+++ b/src/main/java/com/ibm/usecases/scanning/errors/NoGitUrlSpecifiedForScan.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2025 IBM
+ * Copyright (C) 2025 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/errors/NoIndexForProject.java
+++ b/src/main/java/com/ibm/usecases/scanning/errors/NoIndexForProject.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/errors/NoProjectDirectoryProvided.java
+++ b/src/main/java/com/ibm/usecases/scanning/errors/NoProjectDirectoryProvided.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/errors/NoPurlSpecifiedForScan.java
+++ b/src/main/java/com/ibm/usecases/scanning/errors/NoPurlSpecifiedForScan.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2025 IBM
+ * Copyright (C) 2025 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/errors/PurlResolutionFailed.java
+++ b/src/main/java/com/ibm/usecases/scanning/errors/PurlResolutionFailed.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/errors/ScanCleanUpOnErrorFailed.java
+++ b/src/main/java/com/ibm/usecases/scanning/errors/ScanCleanUpOnErrorFailed.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/errors/UnexpectedIdentifier.java
+++ b/src/main/java/com/ibm/usecases/scanning/errors/UnexpectedIdentifier.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/eventhandler/ScanEventHandler.java
+++ b/src/main/java/com/ibm/usecases/scanning/eventhandler/ScanEventHandler.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/processmanager/ScanProcessManager.java
+++ b/src/main/java/com/ibm/usecases/scanning/processmanager/ScanProcessManager.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/projector/CBOMProjector.java
+++ b/src/main/java/com/ibm/usecases/scanning/projector/CBOMProjector.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/git/CloneResultDTO.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/git/CloneResultDTO.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/git/GitProgressMonitor.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/git/GitProgressMonitor.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/git/GitService.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/git/GitService.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/indexing/IBuildType.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/indexing/IBuildType.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2025 IBM
+ * Copyright (C) 2025 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/indexing/IndexingService.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/indexing/IndexingService.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/indexing/JavaBuildType.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/indexing/JavaBuildType.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2025 IBM
+ * Copyright (C) 2025 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/indexing/JavaIndexService.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/indexing/JavaIndexService.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/indexing/ProjectModule.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/indexing/ProjectModule.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/indexing/PythonBuildType.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/indexing/PythonBuildType.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2025 IBM
+ * Copyright (C) 2025 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/indexing/PythonIndexService.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/indexing/PythonIndexService.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/pkg/MavenPackageFinderService.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/pkg/MavenPackageFinderService.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2025 IBM
+ * Copyright (C) 2025 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/pkg/PackageFinderService.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/pkg/PackageFinderService.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2025 IBM
+ * Copyright (C) 2025 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/pkg/SetupPackageFinderService.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/pkg/SetupPackageFinderService.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2025 IBM
+ * Copyright (C) 2025 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/pkg/TomlPackageFinderService.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/pkg/TomlPackageFinderService.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2025 IBM
+ * Copyright (C) 2025 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/resolve/DepsDevService.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/resolve/DepsDevService.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/resolve/GithubPurlResolver.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/resolve/GithubPurlResolver.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/resolve/PurlResolver.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/resolve/PurlResolver.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/scan/IScannerService.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/scan/IScannerService.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/scan/ScanResultDTO.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/scan/ScanResultDTO.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/scan/ScannerService.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/scan/ScannerService.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/scan/java/JavaAstScannerExtension.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/scan/java/JavaAstScannerExtension.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/scan/java/JavaDetectionCollectionRule.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/scan/java/JavaDetectionCollectionRule.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/scan/java/JavaScannerService.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/scan/java/JavaScannerService.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/scan/python/PythonDetectionCollectionRule.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/scan/python/PythonDetectionCollectionRule.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/scan/python/PythonScannableFile.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/scan/python/PythonScannableFile.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/main/java/com/ibm/usecases/scanning/services/scan/python/PythonScannerService.java
+++ b/src/main/java/com/ibm/usecases/scanning/services/scan/python/PythonScannerService.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2024 IBM
+ * Copyright (C) 2024 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/test/java/com/ibm/architecture/DomainTest.java
+++ b/src/test/java/com/ibm/architecture/DomainTest.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2025 IBM
+ * Copyright (C) 2025 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/test/java/com/ibm/usecases/scanning/services/indexing/JavaIndexServiceTest.java
+++ b/src/test/java/com/ibm/usecases/scanning/services/indexing/JavaIndexServiceTest.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2025 IBM
+ * Copyright (C) 2025 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/test/java/com/ibm/usecases/scanning/services/indexing/PythonIndexServiceTest.java
+++ b/src/test/java/com/ibm/usecases/scanning/services/indexing/PythonIndexServiceTest.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2025 IBM
+ * Copyright (C) 2025 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/test/java/com/ibm/usecases/scanning/services/scan/JavaScannerServiceTest.java
+++ b/src/test/java/com/ibm/usecases/scanning/services/scan/JavaScannerServiceTest.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2025 IBM
+ * Copyright (C) 2025 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/test/java/com/ibm/usecases/scanning/services/scan/PythonScannerServiceTest.java
+++ b/src/test/java/com/ibm/usecases/scanning/services/scan/PythonScannerServiceTest.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2025 IBM
+ * Copyright (C) 2025 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/src/test/java/com/ibm/utils/AssetableProgressDispatcher.java
+++ b/src/test/java/com/ibm/utils/AssetableProgressDispatcher.java
@@ -1,6 +1,6 @@
 /*
  * CBOMkit
- * Copyright (C) 2025 IBM
+ * Copyright (C) 2025 PQCA
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
This PR replaces IBM with PQCA in license header