### PR TITLE
fixed protobuf error - issue #254

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,12 @@
       <version>${google-java-format.version}</version>
     </dependency>
 
+    <dependency> <!-- Fixes issue #138 -->
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>4.31.1</version> <!-- Use the latest stable version -->
+    </dependency>
+
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>


### PR DESCRIPTION
This fixes issue #254
- This is the old issue #138 (hanging python scan when running in container)
- Observed when scanning keycloak. The repo contains a some python files which are not excluded in cbomkit.
- Including explicit dependency on `com.google.protobuf/protobuf-java@4.31.1` fixes the problem