### PR TITLE
fix: Prevent failing with NPE on `null` list

### DIFF
--- a/src/main/java/com/ibm/usecases/compliance/service/CompliancePreparationService.java
+++ b/src/main/java/com/ibm/usecases/compliance/service/CompliancePreparationService.java
@@ -27,6 +27,9 @@ import com.ibm.usecases.compliance.errors.ErrorWhileParsingStringToCBOM;
 import jakarta.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
 import org.cyclonedx.exception.ParseException;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.parsers.BomParserFactory;
@@ -45,7 +48,9 @@ public final class CompliancePreparationService {
                         .orElseThrow(() -> new CouldNotFindCBOMForGitRepository(projectIdentifier));
 
         final CBOM cbom = CBOM.formJSON(cbomReadModel.getBom());
-        return cbom.cycloneDXbom().getComponents().stream()
+        return Optional.ofNullable(cbom.cycloneDXbom().getComponents())
+                .orElseGet(List::of)
+                .stream()
                 .map(component -> new CryptographicAsset(component.getBomRef(), component))
                 .toList();
     }
@@ -58,7 +63,9 @@ public final class CompliancePreparationService {
             Parser parser = BomParserFactory.createParser(cbomBytes);
             // Parse the BOM content
             Bom cycloneDXbom = parser.parse(cbomBytes);
-            return cycloneDXbom.getComponents().stream()
+            return Optional.ofNullable(cycloneDXbom.getComponents())
+                    .orElseGet(List::of)
+                    .stream()
                     .map(component -> new CryptographicAsset(component.getBomRef(), component))
                     .toList();
         } catch (ParseException e) {


### PR DESCRIPTION
If the component list is `null`, this is now treated as an empty list. Not failing the scan.

Close: #260