### PR TITLE
Added CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,8 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+  - name: "IBM Research Europe–Zurich"
+title: "CBOMkit"
+version: 2.2.2
+date-released: 2026-02-05
+url: "https://github.com/cbomkit/cbomkit"


### PR DESCRIPTION
This PR adds a CITATION.cff file to the repo, making it easy for researchers and developers to cite CBOMkit in papers or reports.

Once merged, Github will show a "Cite this repository" button in the sidebar, letting users copy citations in APA or BibTeX formats.

Details (can be revised):
- Author: IBM Research Europe-Zurich
- Version: 2.2.2
- Release Date: 2026-02-05

[Read more about CITATION files here.](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files)