### PR TITLE
ECCG external policy

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,12 @@
+services:
+  opa:
+    image: openpolicyagent/opa:0.66.0
+    command:
+      - "run"
+      - "--server"
+      - "--addr=0.0.0.0:8181"
+      - "/policies"
+    ports:
+      - "8181:8181"
+    volumes:
+      - ./policies:/policies:ro


### PR DESCRIPTION
This refers to issue #328. 

# Tasks
- [ ] Implement ECCG ENISA cryptographic policy.    
# Questions 

1. There are a lot of instances in the [ECCG ENISA Policy](https://certification.enisa.europa.eu/document/download/a845662b-aee0-484e-9191-890c4cfa7aaa_en?filename=ECCG%20Agreed%20Cryptographic%20Mechanisms%20version%202.pdf), where there are requirements for key size, of hash size etc. For example the system should somehow flag the usage of SHA-3 with hash size of 256 bits are non quantum-resistant, as seen in the below table.  Can the CBOM kit code analysis engine extract these parameters? 
<img width="646" height="274" alt="image" src="https://github.com/user-attachments/assets/cd2778f4-e1a7-4ceb-8832-1d9076f82fff" />

Source [ECCG ENISA Policy](https://certification.enisa.europa.eu/document/download/a845662b-aee0-484e-9191-890c4cfa7aaa_en?filename=ECCG%20Agreed%20Cryptographic%20Mechanisms%20version%202.pdf)

2. Where in the code should the CBOMs be sent to the OPA container?  

3. Is the docker-compose override idea correct here? 